### PR TITLE
Fixed Crash for empty Activity and added Toast

### DIFF
--- a/app/src/main/java/work/technie/motonavigator/fragment/MapFragment.java
+++ b/app/src/main/java/work/technie/motonavigator/fragment/MapFragment.java
@@ -658,6 +658,7 @@ public class MapFragment extends Fragment {
         final Location[] newLocation = {null};
         final FlagGPSOneTime gps = new FlagGPSOneTime();
         if (enabled) {
+            Toast.makeText(mActivity,"Loading current location",Toast.LENGTH_SHORT).show();
             map.setMyLocationEnabled(true);
             locationServices.addLocationListener(new LocationListener() {
                 @Override
@@ -673,9 +674,12 @@ public class MapFragment extends Fragment {
                         IconFactory iconFactory = IconFactory.getInstance(mActivity);
                         Drawable iconDrawable = ContextCompat.getDrawable(mActivity, R.drawable.default_marker);
                         Icon icon = iconFactory.fromDrawable(iconDrawable);
+                        Activity activity = getActivity();
+                        if (isAdded() && activity != null) {
+                            markerOrigin = map.addMarker(new MarkerOptions()
+                                    .position(new LatLng(location.getLatitude(), location.getLongitude())).title(getString(R.string.origin)).icon(icon));
+                        }
 
-                        markerOrigin = map.addMarker(new MarkerOptions()
-                                .position(new LatLng(location.getLatitude(), location.getLongitude())).title(getString(R.string.origin)).icon(icon));
 
 
                         markerOrigin.setPosition(new LatLng(location.getLatitude(), location.getLongitude()));


### PR DESCRIPTION
- Fixed a crash which is caused by the map fragment acvtivity when activity is switched while current location is fetched on the location floating button is pressed.
error : Fragment MapFragment{8628b75} not attached to Activity. 
![screenshot from 2018-02-06 01-05-45](https://user-images.githubusercontent.com/18641688/35824789-fc125492-0ad9-11e8-91ee-85f9f0e4ce42.png)

- Added toast to show that Location is being loading when floating action button is pressed.
